### PR TITLE
add evr name to config, remove reliance on default evr detector

### DIFF
--- a/jet_tracking/jet_tracking_cal/jt_cal.py
+++ b/jet_tracking/jet_tracking_cal/jt_cal.py
@@ -350,6 +350,7 @@ if __name__ == '__main__':
             run = yml_dict['run']
         cal_params = yml_dict['cal_params']
         ffb = yml_dict['ffb']
+        evr_name = yml_dict['evr_name']
         event_code = yml_dict['event_code']
 
     if jet_cam_name == 'None' or jet_cam_name == 'none':
@@ -390,7 +391,7 @@ if __name__ == '__main__':
         ipm = psana.Detector(ipm_name)
         if jet_cam_name is not None:
             jet_cam = psana.Detector(jet_cam_name)
-        evr = get_evr_w_codes(psana.DetNames())
+        evr = psana.Detector(evr_name)
         masks = get_r_masks(det_map['shape'], cal_params['azav_bins'])
     except Exception as e:
         logger.warning('Unable to create psana detectors: {}'.format(e))
@@ -439,7 +440,7 @@ if __name__ == '__main__':
         except Exception as e:
             logger.info('Unable to process event {}: {}'.format(evt_idx, e))
 
-        if evt_idx == num_events:
+        if evt_idx > num_events:
             break
 
     smd.save()

--- a/jet_tracking/jt_configs/cxi_config.yml
+++ b/jet_tracking/jt_configs/cxi_config.yml
@@ -6,6 +6,7 @@ experiment: 'cxip21119'
 run: '1'
 sim: false
 ffb: true
+evr_name: 'evr1'
 event_code: 40 # x-ray on event code
 
 det_map:

--- a/jet_tracking/jt_configs/cxi_dsd_config.yml
+++ b/jet_tracking/jt_configs/cxi_dsd_config.yml
@@ -6,6 +6,7 @@ experiment: 'cxix53419'
 run: '1'
 sim: false
 ffb: true
+evr_name: 'evr1'
 event_code: 40 # x-ray on event code
 
 det_map:

--- a/jet_tracking/jt_configs/cxi_dsd_config.yml
+++ b/jet_tracking/jt_configs/cxi_dsd_config.yml
@@ -6,7 +6,7 @@ experiment: 'cxix53419'
 run: '1'
 sim: false
 ffb: true
-evr_name: 'evr1'
+evr_name: 'evr0'
 event_code: 40 # x-ray on event code
 
 det_map:

--- a/jet_tracking/jt_configs/mfx_epix_config.yml
+++ b/jet_tracking/jt_configs/mfx_epix_config.yml
@@ -6,6 +6,7 @@ experiment: 'mfxx45919'
 run: '1'
 sim: false
 ffb: true
+evr_name: 'evr0'
 event_code: 40 # x-ray on event code
 
 det_map:

--- a/jet_tracking/jt_configs/xcs_config.yml
+++ b/jet_tracking/jt_configs/xcs_config.yml
@@ -6,6 +6,7 @@ experiment: 'xcsx47519'
 run: '10'
 sim: true
 ffb: false
+evr_name: 'evr0'
 event_code: 137 # x-ray on event code
 
 det_map:

--- a/jet_tracking/mpi_scripts/mpi_driver.py
+++ b/jet_tracking/mpi_scripts/mpi_driver.py
@@ -42,6 +42,7 @@ with open(args.cfg_file) as f:
     hutch = yml_dict['hutch']
     exp = yml_dict['experiment']
     run = yml_dict['run']
+    evr_name = yml_dict['evr_name']
     event_code = yml_dict['event_code']
     # wf_length = yml_dict['wf_length']
 
@@ -81,7 +82,7 @@ if jet_cam_name is not None:
     jet_cam = psana.Detector(jet_cam_name)
 else:
     jet_cam = None
-evr = get_evr_w_codes(psana.DetNames())
+evr = psana.Detector(evr_name)
 print(evr.name)
 print(pv_map)
 r_mask = get_r_masks(det_map['shape'])

--- a/jet_tracking/mpi_scripts/mpi_driver.py
+++ b/jet_tracking/mpi_scripts/mpi_driver.py
@@ -83,8 +83,6 @@ if jet_cam_name is not None:
 else:
     jet_cam = None
 evr = psana.Detector(evr_name)
-print(evr.name)
-print(pv_map)
 r_mask = get_r_masks(det_map['shape'])
 
 if rank == 0:


### PR DESCRIPTION
Add the evr detector name to config files

## Description
Each config file must now specify which evr detector to instantiate, under evr_name.

## Motivation and Context
Avoid defaulting to wrong EVR detector.

## How Has This Been Tested?
Tested at CXI running both calibration and mpi scripts.

## Where Has This Been Documented?
Nowhere
