### PR TITLE
add rayonix support for MFX

### DIFF
--- a/jet_tracking/jet_tracking_cal/jt_cal.py
+++ b/jet_tracking/jet_tracking_cal/jt_cal.py
@@ -407,12 +407,13 @@ if __name__ == '__main__':
         if evt_idx % 10 == 0:
             print('Event: {}'.format(evt_idx))
         try:
-            print(event_code)
-            print(type(event_code))
             if event_code not in evr.eventCodes(evt):
                 continue
             # Get image and azav
             calib = detector.calib(evt)
+            if calib is None:
+                print(f'No data in shot #{evt_idx}')
+                continue
             calib = calib * psana_mask
             det_image = detector.image(evt, calib)
             azav = np.array([np.mean(det_image[mask]) for mask in masks])

--- a/jet_tracking/jt_configs/mfx_rayonix_config.yml
+++ b/jet_tracking/jt_configs/mfx_rayonix_config.yml
@@ -2,17 +2,18 @@ api_msg:
   port: 5000
 
 hutch: 'mfx'
-experiment: 'mfxx45919'
-run: '1'
-sim: false
-ffb: true
+experiment: 'mfxlw7519'
+run: '17'
+sim: true
+ffb: false
+evr_name: 'evr0'
 event_code: 198 # x-ray on event code
 
 det_map:
   name: 'Rayonix'
   shape:
-    - 960
-    - 960
+    - 1920
+    - 1920
   dtype: float32
   bins: 100
 

--- a/jet_tracking/mpi_scripts/mpi_worker.py
+++ b/jet_tracking/mpi_scripts/mpi_worker.py
@@ -141,6 +141,9 @@ class MpiWorker(object):
 
                     # Detector images
                     calib = self.detector.calib(evt)
+                    if calib is None:
+                        print(f'No data in shot #{evt_idx}')
+                        continue
                     calib = calib*psana_mask
                     det_image = self.detector.image(evt, calib)
                     az_bins = (np.array([np.mean(det_image[mask])


### PR DESCRIPTION

## Description
Add a config file for the Rayonix detector at MFX upon request from Frank. Flag None detector data (happen often with the Rayonix)

## Motivation and Context
Requested by scientists

## How Has This Been Tested?
Calibration and script tested on lw75, run 11. Signal looks weird though, but the physics of the system might just be different. Needs to loop back with Frank to see if we want to modify some of the analysis to cater to this type of signal.

## Where Has This Been Documented?
Nowhere

